### PR TITLE
I tried to update to Minecraft 1.21.5 and PacketEvents 2.8.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>ProdigyCape</name>
 
     <properties>
-        <java.version>16</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>com.github.retrooper</groupId>
             <artifactId>packetevents-spigot</artifactId>
-            <version>2.4.0</version>
+            <version>2.8.0</version>
             <scope>compile</scope>
         </dependency>
 
@@ -130,14 +130,14 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19.4-R0.1-SNAPSHOT</version>
+            <version>1.21.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.github.Tofaa2.EntityLib</groupId>
             <artifactId>spigot</artifactId>
-            <version>2.3.1-SNAPSHOT</version>
+            <version>master-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/fr/cocoraid/prodigycape/ProdigyCape.java
+++ b/src/main/java/fr/cocoraid/prodigycape/ProdigyCape.java
@@ -98,7 +98,6 @@ public final class ProdigyCape extends JavaPlugin {
 
         APIConfig settings = new APIConfig(PacketEvents.getAPI())
                 .tickTickables()
-                .trackPlatformEntities()
                 .usePlatformLogger();
 
         EntityLib.init(platform, settings);

--- a/src/main/java/fr/cocoraid/prodigycape/cape/PlayerCape.java
+++ b/src/main/java/fr/cocoraid/prodigycape/cape/PlayerCape.java
@@ -121,7 +121,7 @@ public class PlayerCape {
         this.lastBodyYaw = player.getLocation().getYaw();
         this.currentBodyYaw = player.getLocation().getYaw();
 
-        capeDisplay = EntityLib.getApi().createEntity(EntityTypes.ITEM_DISPLAY);
+        capeDisplay = EntityLib.getApi().createEntity(EntityTypes.ITEM_DISPLAY, player.getLocation());
         forceSpawn(player);
 
         task = new BukkitRunnable() {
@@ -309,7 +309,7 @@ public class PlayerCape {
             Vector3f translationVector = new Vector3f(0, y_offset, 0).add(backwardOffset);
 
             meta.setTranslation(new com.github.retrooper.packetevents.util.Vector3f(translationVector.x, translationVector.y, translationVector.z));
-            WrapperPlayServerEntityMetadata metadata = new WrapperPlayServerEntityMetadata(capeDisplay.getEntityId(), meta.entityData());
+            WrapperPlayServerEntityMetadata metadata = new WrapperPlayServerEntityMetadata(capeDisplay.getEntityId(), meta);
 
             playerManager.sendPacket(p, metadata);
 

--- a/src/main/java/fr/cocoraid/prodigycape/commands/CapeCommand.java
+++ b/src/main/java/fr/cocoraid/prodigycape/commands/CapeCommand.java
@@ -60,8 +60,9 @@ public class CapeCommand extends BaseCommand {
     public void onCapeTest(Player player) {
         byte isCape = (byte) (toggleCape ? 126 : 127);
         EntityData data = new EntityData(17, EntityDataTypes.BYTE, (byte) isCape);
-        WrapperPlayServerEntityMetadata metadata = new WrapperPlayServerEntityMetadata(player.getEntityId(), List.of(data));
-        playerManager.sendPacket(player, metadata);
+        List<EntityData<?>> metadataList = java.util.List.of(data);
+        WrapperPlayServerEntityMetadata metadataPacket = new WrapperPlayServerEntityMetadata(player.getEntityId(), metadataList);
+        playerManager.sendPacket(player, metadataPacket);
         toggleCape = !toggleCape;
         player.sendMessage("§aCape toggled to " + (toggleCape ? "ON" : "OFF"));
     }

--- a/src/main/java/fr/cocoraid/prodigycape/listener/JoinQuitListener.java
+++ b/src/main/java/fr/cocoraid/prodigycape/listener/JoinQuitListener.java
@@ -46,10 +46,12 @@ public class JoinQuitListener implements Listener {
         new BukkitRunnable() {
             @Override
             public void run() {
-                EntityData data = new EntityData(17, EntityDataTypes.BYTE, (byte) 126);
-                WrapperPlayServerEntityMetadata metadata = new WrapperPlayServerEntityMetadata(player.getEntityId(), List.of(data));
+                EntityData dataLine50 = new EntityData(17, EntityDataTypes.BYTE, (byte) 126); // Renamed to avoid conflict if 'data' is used later
+                List<EntityData<?>> metadataListLine50 = java.util.List.of(dataLine50);
+                WrapperPlayServerEntityMetadata metadataPacketLine50 = new WrapperPlayServerEntityMetadata(player.getEntityId(), metadataListLine50);
+                // The existing loop:
                 Bukkit.getOnlinePlayers().forEach(cur -> {
-                    playerManager.sendPacket(cur, metadata);
+                    playerManager.sendPacket(cur, metadataPacketLine50);
                 });
 
             }
@@ -97,10 +99,12 @@ public class JoinQuitListener implements Listener {
         new BukkitRunnable() {
             @Override
             public void run() {
-                EntityData data = new EntityData(17, EntityDataTypes.BYTE, (byte) 126);
-                WrapperPlayServerEntityMetadata metadata = new WrapperPlayServerEntityMetadata(player.getEntityId(), List.of(data));
+                EntityData dataLine101 = new EntityData(17, EntityDataTypes.BYTE, (byte) 126); // Renamed
+                List<EntityData<?>> metadataListLine101 = java.util.List.of(dataLine101);
+                WrapperPlayServerEntityMetadata metadataPacketLine101 = new WrapperPlayServerEntityMetadata(player.getEntityId(), metadataListLine101);
+                // The existing loop:
                 Bukkit.getOnlinePlayers().forEach(cur -> {
-                    playerManager.sendPacket(cur, metadata);
+                    playerManager.sendPacket(cur, metadataPacketLine101);
                 });
 
             }


### PR DESCRIPTION
I updated your pom.xml with:
- Minecraft (Spigot API) to 1.21.5-R0.1-SNAPSHOT
- PacketEvents to 2.8.0
- Java version to 17
- EntityLib to master-SNAPSHOT (as 2.3.1-SNAPSHOT was unavailable)

I also made some code changes to adapt to API updates:
- Removed .trackPlatformEntities() from APIConfig in ProdigyCape.java.
- Updated WrapperPlayServerEntityMetadata constructor calls:
    - In PlayerCape.java, using ItemDisplayMeta directly as the provider.
    - In CapeCommand.java and JoinQuitListener.java, using List.of(EntityData) directly.

Currently, the build is failing.

The main problem is a compilation error in PlayerCape.java: `cannot find symbol: method createEntity(com.github.retrooper.packetevents.protocol.entity.type.EntityType) location: interface me.tofaa.entitylib.EntityLibAPI<java.lang.Object>`

I also tried using `createEntity(EntityType, Location)`, but that didn't work either. I'm not sure what the correct method signature or replacement is for creating entities with EntityLib master-SNAPSHOT because I couldn't find the documentation or source code for this specific version. I'll need to look into EntityLib's API more to figure this out.