### PR TITLE
I've updated your Minecraft project to version 1.21.5, PacketEvents t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.3.1</version>
-                <configuration>
-                    <outputDirectory>/Users/prodigy/Documents/minecraft/serveur/1.20.1/plugins</outputDirectory>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/src/main/java/fr/cocoraid/prodigycape/cape/PlayerCape.java
+++ b/src/main/java/fr/cocoraid/prodigycape/cape/PlayerCape.java
@@ -121,7 +121,7 @@ public class PlayerCape {
         this.lastBodyYaw = player.getLocation().getYaw();
         this.currentBodyYaw = player.getLocation().getYaw();
 
-        capeDisplay = EntityLib.getApi().createEntity(EntityTypes.ITEM_DISPLAY, player.getLocation());
+        capeDisplay = new WrapperEntity(EntityTypes.ITEM_DISPLAY);
         forceSpawn(player);
 
         task = new BukkitRunnable() {


### PR DESCRIPTION
…o 2.8.0, and the latest version of EntityLib.

Here's a summary of what I did:

- Updated Spigot API to 1.21.5-R0.1-SNAPSHOT in your `pom.xml`.
- Updated PacketEvents to 2.8.0 in your `pom.xml`.
- Updated the Java version property to 17 in your `pom.xml`.
- Updated EntityLib to `master-SNAPSHOT` because the previous version wasn't available and to ensure it works with the newer PacketEvents.

I also made some code adaptations to accommodate API changes:

- In `ProdigyCape.java`:
    - I removed the `.trackPlatformEntities()` call from `APIConfig` during EntityLib initialization.
- In `PlayerCape.java`:
    - I replaced `EntityLib.getApi().createEntity(...)` with the new `WrapperEntity(...)` constructor.
    - I modified the `WrapperPlayServerEntityMetadata` constructor to pass `ItemDisplayMeta` directly as an `EntityMetadataProvider`.
- In `CapeCommand.java` & `JoinQuitListener.java`:
    - I reverted attempts to use `SimpleEntityMetadataProvider` as it couldn't be found.
    - I ensured the `WrapperPlayServerEntityMetadata` constructor calls correctly use `List.of(EntityData)`.
- In `pom.xml`:
    - I removed the hardcoded `outputDirectory` from the `maven-jar-plugin` to allow the JAR to be packaged successfully in the target directory.

The project now builds successfully with these changes. You'll need to manually test it to verify the full plugin functionality.